### PR TITLE
+ add options map (for now to be able to turn off logging)

### DIFF
--- a/src/clj_slack_client/connectivity.clj
+++ b/src/clj_slack_client/connectivity.clj
@@ -9,6 +9,8 @@
     [clj-time.core :as time]))
 
 
+(def ^:dynamic *options* nil)
+
 (def ^:dynamic *reconnect* nil)
 
 (def ^:dynamic *websocket-stream* nil)
@@ -69,7 +71,8 @@
       "pong" (swap! last-pong-time (constantly (time/now))) ;; todo host callback for this message-id?
       "team_migration_started" (*reconnect*)
       "default")
-    (when (not= event-type "pong")
+    (when (and (*options* :log)
+               (not= event-type "pong"))
       (println event))))
 
 
@@ -79,8 +82,9 @@
 
 
 (defn start-real-time
-  [api-token set-team-state pass-event-to-rx reconnect]
+  [api-token set-team-state pass-event-to-rx reconnect options]
   (alter-var-root (var *reconnect*) (constantly reconnect))
+  (alter-var-root (var *options*) (constantly options))
   (let [response-body (web/rtm-start api-token)
         ws-url (:url response-body)
         ws-stream (connect-websocket-stream ws-url)]

--- a/src/clj_slack_client/core.clj
+++ b/src/clj_slack_client/core.clj
@@ -15,17 +15,20 @@
 
 
 (defn connect
-  [api-token host-handle-event]
-  (let [rx-event-stream (stream/stream 8)
-        pass-event-to-rx #(stream/put! rx-event-stream %)
-        host-event-stream (stream/stream 8)
-        pass-event-to-host #(stream/put! host-event-stream %)
-        reconnect (fn [] (do (println "reconnecting...")
-                             (disconnect)
-                             (connect api-token host-handle-event)))]
-    (stream/consume #(rx/handle-event % pass-event-to-host) rx-event-stream)
-    (stream/consume host-handle-event host-event-stream)
-    (conn/start-real-time api-token state/set-team-state pass-event-to-rx reconnect)))
+  ([api-token host-handle-event]
+   (connect api-token host-handle-event {:log true}))
+  ([api-token host-handle-event options]
+   (let [rx-event-stream (stream/stream 8)
+         pass-event-to-rx #(stream/put! rx-event-stream %)
+         host-event-stream (stream/stream 8)
+         pass-event-to-host #(stream/put! host-event-stream %)
+         reconnect (fn [] (do (when (options :log)
+                                (println "reconnecting..."))
+                              (disconnect)
+                              (connect api-token host-handle-event)))]
+     (stream/consume #(rx/handle-event % pass-event-to-host) rx-event-stream)
+     (stream/consume host-handle-event host-event-stream)
+     (conn/start-real-time api-token state/set-team-state pass-event-to-rx reconnect options))))
 
 
 (defn time->ts


### PR DESCRIPTION
The motivation is to be able to turn off the verbose logging (println).
Better alternative would be using log4j or something similar. But this works :)

``` clojure
(connect "token"
         handler
         {:log false})

(connect "token"
         handler
         {:log true})

(connect "token"
         handler) ; as if {:log true}
```
