### PR TITLE
Bump all deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject clj-slack-client "0.1.6-SNAPSHOT"
+(defproject clj-slack-client "0.1.7-SNAPSHOT"
   :description "A client for Slack's RTM and Web APIs"
   :url ""
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [cheshire "5.4.0"]
-                 [aleph "0.4.0"]
-                 [byte-streams "0.2.0"]
-                 [clj-time "0.9.0"]])
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [cheshire "5.8.0"]
+                 [aleph "0.4.3"]
+                 [byte-streams "0.2.3"]
+                 [clj-time "0.14.2"]])


### PR DESCRIPTION
All deps have been updated and are at their latest version. 
Aleph is the exception, as 0.4.4 has an issue getting netty.
Clojure has been bumped to 1.9.0. This does not appear to
have issues with backwards compatibility. Bots written for
0.1.6 should also run just fine on 0.1.7.