### PR TITLE
Do Not Disturb module

### DIFF
--- a/doc/dnd.md
+++ b/doc/dnd.md
@@ -39,10 +39,21 @@ DnD timer given a response from the `get-dnd-response` function. It
 takes a start timestamp and a response map. A useful way to get this
 starting timestamp is the `:ts` atom from a message sent by Slack.
 
+### `set-snooze`
+
+Starts DnD for a particular number of minutes. Needs to be called by a
+non-bot.
+
+### `end-snooze` and `end-dnd`
+
+These end the Snooze and DnD modes, or do nothing if sessions are not
+activated. These need to be called by a non-bot.
+
 ## Using `dnd` with a bot
 
 A useful way to utilize these functions for a bot is by wrapping some
-of the functions to leverage the Slack messages. The [pomodoro bot]()
+of the functions to leverage the Slack messages. The
+[pomodoro bot](https://github.com/the-mikedavis/pomodoro/blob/master/src/pomodoro/status.clj)
 has some wrappers which deal solely with messages and responses. The
 wrapper function converts the results of these API calls to strings,
 which are then sent by the bot to the asking user.

--- a/doc/dnd.md
+++ b/doc/dnd.md
@@ -1,0 +1,48 @@
+# Do Not Disturb
+
+Slack has a very straight forward and useful Do Not Disturb feature.
+
+Here are the four options:
+
+- `dnd.info`: DnD info for a specific user
+- `dnd.teamInfo`: DnD info for a whole team
+- `dnd.setSnooze`: turn on DnD for a user for a specified time
+- `dnd.endSnooze`: turn off DnD for a user
+
+> **N.B.**: the last two are currently not accessible by bot. Trying to
+use the methods will result in an error.
+
+The `clj-slack-client.dnd` module has just a few functions for accessing
+these api methods and avoiding some basic pitfalls.
+
+### `time-difference`
+
+The first is a basic function to investigate time stamps. It takes two
+time stamps and returns the difference between them. The time stamps
+are intended to be in seconds, which is what the Slack API responses
+return. The value returned is a hashmap with fields:
+
+- `:min` minutes
+- `:sec` seconds
+- `:str` a string taking the form `<min>:<sec>` (i.e. _clock-time_)
+
+### `get-user-dnd` and `get-team-dnd`
+
+These functions get the API response maps for the API methods `dnd.info`
+and `dnd.teamInfo` respectively. The responses from these can be fed to
+`time-delta` to figure out the time remaining on a DnD timer.
+
+### `time-delta`
+
+This function uses `time-difference` to return the time remaining on a
+DnD timer given a response from the `get-dnd-response` function. It
+takes a start timestamp and a response map. A useful way to get this
+starting timestamp is the `:ts` atom from a message sent by Slack.
+
+## Using `dnd` with a bot
+
+A useful way to utilize these functions for a bot is by wrapping some
+of the functions to leverage the Slack messages. The [pomodoro bot]()
+has some wrappers which deal solely with messages and responses. The
+wrapper function converts the results of these API calls to strings,
+which are then sent by the bot to the asking user.

--- a/src/clj_slack_client/dnd.clj
+++ b/src/clj_slack_client/dnd.clj
@@ -38,3 +38,24 @@
   [time-stamp response]
   (time-difference time-stamp
                    (:next_dnd_end_ts response)))
+
+; These methods require a non-bot api-token. These have been written
+; in the hopes that these methods will be accessible in the future.
+
+(defn set-snooze
+  [api-token user-id num-minutes]
+  (web/call-and-get-response
+    "dnd.setSnooze"
+    {:token api-token :num_minutes num_minutes}))
+
+(defn end-snooze
+  [api-token]
+  (web/call-and-get-response
+    "dnd.endSnooze"
+    {:token api-token}))
+
+(defn end-dnd
+  [api-token]
+  (web/call-and-get-response
+    "dnd.endDnd"
+    {:token api-token}))

--- a/src/clj_slack_client/dnd.clj
+++ b/src/clj_slack_client/dnd.clj
@@ -1,0 +1,40 @@
+(ns clj-slack-client.dnd
+  (:require [clj-slack-client.web :as web]))
+
+(defn- cast-int [s]
+  "Pick out an integer from a string, or returns the number passed."
+  (if (number? s)
+    s
+    (Integer. (re-find #"\d+" s))))
+
+(defn time-difference
+  "Given two time stamps, returns a hashmap with atoms :min and :sec
+  giving the time difference. The map also has a :str atom which has
+  a string representation of the commonly used time form <min>:<sec>.
+  The parameters are casted to integer, so :ts Slack time-stamps can
+  be passed as is."
+  [start end]
+  (let [difference (- (cast-int end) (cast-int start))
+        minutes (quot difference 60)
+        seconds (mod  difference 60)]
+    (hash-map :min minutes
+              :sec seconds
+              :str (str minutes ":" seconds))))
+
+(defn get-user-dnd
+  "Call the Slack dnd.info method for a particular user-id."
+  [api-token user-id]
+  (web/call-and-get-response "dnd.info"
+                             {:user user-id :token api-token}))
+
+(defn get-team-dnd
+  "Call the Slack dnd.teamInfo method for the whole team."
+  [api-token]
+  (web/call-and-get-response "dnd.teamInfo" {:token api-token}))
+
+(defn time-delta
+  "Return the time left on a dnd timer from the API response
+  and an initial time-stamp."
+  [time-stamp response]
+  (time-difference time-stamp
+                   (:next_dnd_end_ts response)))

--- a/src/clj_slack_client/dnd.clj
+++ b/src/clj_slack_client/dnd.clj
@@ -46,7 +46,7 @@
   [api-token user-id num-minutes]
   (web/call-and-get-response
     "dnd.setSnooze"
-    {:token api-token :num_minutes num_minutes}))
+    {:token api-token :num_minutes num-minutes}))
 
 (defn end-snooze
   [api-token]


### PR DESCRIPTION
Call the DnD methods from the Slack API. This implements all methods, but 3 of the 5 are not accessible by bots. This PR is dependent on the "abstract-call" PR (#6).