### PR TITLE
Give each api method a function with basic functionality

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-slack-client "0.1.7-SNAPSHOT"
+(defproject clj-slack-client "0.1.8-SNAPSHOT"
   :description "A client for Slack's RTM and Web APIs"
   :url ""
   :license {:name "Eclipse Public License"

--- a/src/clj_slack_client/api.clj
+++ b/src/clj_slack_client/api.clj
@@ -1,0 +1,11 @@
+(ns clj-slack-client.api
+  (:reqire [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [test]))
+
+
+(defn test
+  "Checks API calling code. Callable by workspace and user tokens."
+  ([]
+   (web/call-and-get-response "api.test"))
+  ([options]
+   (web/call-and-get-response "apt.test" options)))

--- a/src/clj_slack_client/apps/permissions.clj
+++ b/src/clj_slack_client/apps/permissions.clj
@@ -1,0 +1,19 @@
+(ns clj-slack-client.apps.permissions
+  (:require [clj-slack-client.web :as web]))
+
+
+(defn info
+  "Returns a list of permissions this app has on a team. Callable
+  only by workspace token."
+  [token]
+  (web/call-and-get-response "apps.permissions.info" {:token token}))
+
+
+(defn request
+  "Allows an app to request additional scopes. Supported by the
+  workspace token type."
+  [token scopes trigger-id]
+  (web/call-and-get-response "apps.permissions.request"
+                             {:token token :scopes scopes
+                              :trigger_id trigger-id}))
+

--- a/src/clj_slack_client/auth.clj
+++ b/src/clj_slack_client/auth.clj
@@ -1,0 +1,22 @@
+(ns clj-slack-client.auth
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [test]))
+
+
+(defn revoke
+  "Revokes a token. Callable by workspace and user tokens.
+  Passing 1 as the second parameter will enter a testing mode
+  which doesn't actually revoke the token."
+  ([token]
+   (revoke token false))
+  ([token test]
+   (web/call-and-get-response "auth.revoke"
+                              {:token token :test test})))
+
+
+(defn test
+  "Checks authentication and identity. Callable by all token
+  types."
+  [token]
+  (web/call-and-get-response "auth.test" {:token token}))
+

--- a/src/clj_slack_client/bots.clj
+++ b/src/clj_slack_client/bots.clj
@@ -1,0 +1,11 @@
+(ns clj-slack-client.bots
+  (:require [clj-slack-client.web :as web]))
+
+
+(defn info
+  "Gets information about a bot user. Callable by all token types."
+  ([token]
+   (web/call-and-get-response "bots.info" {:token token}))
+  ([token bot]
+   (web/call-and-get-response "bots.info"
+                              {:token token :bot bot})))

--- a/src/clj_slack_client/channels.clj
+++ b/src/clj_slack_client/channels.clj
@@ -1,0 +1,126 @@
+(ns clj-slack-client.channels
+  (:require [clj-slack-client.web :as web]))
+
+
+(defn archive
+  "Archives a channel. Acessible by workspace and user (not bots)."
+  [token channel]
+  (web/call-and-get-response "channels.archive"
+                             {:token token :channel channel}))
+
+
+(defn create
+  "Creates a channel. Accessible by workspace and user (not bots)."
+  ([token channel-name]
+   (create token false))
+  ([token channel-name validate]
+   (web/call-and-get-response "channels.create"
+                              {:token token :name channel-name
+                               :validate validate})))
+
+
+; there are extensive options. check api.slack.com/methods/channels.history
+(defn history
+  "Fetches history of messages and events from a channel. Accessible
+  by bots, workspaces, and users."
+  ([token channel]
+   (history token channel {}))
+  ([token channel options]
+   (web/call-and-get-response "channels.history"
+                              (merge {:token token :channel channel}
+                                     options))))
+
+
+(defn info
+  "Gets the information about a channel. Accessible by bots, workspaces,
+  and users."
+  ([token channel]
+   (info token channel false))
+  ([token channel include-locale]
+   (web/call-and-get-response "channels.info"
+                              {:token token :channel channel
+                               :include_locale include-locale})))
+
+
+(defn invite
+  "Invites a user to a channel. Only accessible by workspace or user."
+  [token channel user-id]
+  (web/call-and-get-response "channels.invite"
+                             {:token token :channel channel :user user-id}))
+
+
+(defn join
+  "Joins a channel, creating it if needed. Only accessible by user tokens."
+  ([token channel-name]
+   (join token channel-name false))
+  ([token channel-name validate]
+   (web/call-and-get-response "channels.join"
+                              {:token token :name channel-name
+                               :validate validate})))
+
+
+(defn kick
+  "Removes a user from a channel. Accessible by workspace and user tokens."
+  [token channel user-id]
+  (web/call-and-get-response "channels.kick"
+                             {:token token :channel channel :user user-id}))
+
+
+(defn leave
+  "Leave a channel. Accessible by user only."
+  [token channel]
+  (web/call-and-get-response "channels.leave"
+                             {:token token :channel channel}))
+
+
+(defn mark
+  "Sets the read cursor in a channel. Accessible by bots and users."
+  [token channel time-stamp]
+  (web/call-and-get-response "channels.mark"
+                             {:token token :channel channel
+                              :ts time-stamp}))
+
+
+(defn rename
+  "Renames a channel. Accessible by workspace and user tokens."
+  ([token channel new-name]
+   (rename token channel new-name false))
+  ([token channel new-name validate]
+   (web/call-and-get-response "channels.rename"
+                              {:token token :channel channel
+                               :name new-name :validate validate})))
+
+
+(defn replies
+  "Retrieve a thread of messages posted to a channel. Accessible
+  by bots, workspaces, and users."
+  [token channel thread-ts]
+  (web/call-and-get-response "channels.replies"
+                             {:token token :channel channel
+                              :thread_ts thread-ts}))
+
+
+(defn set-purpose
+  "Sets the purpose for a channel. Accessible by bots, workspaces,
+  and users."
+  [token channel purpose]
+  (web/call-and-get-response "channels.setPurpose"
+                             {:token token :channel channel
+                              :purpose purpose}))
+
+
+(defn setTopic
+  "Sets the topic for a channel. Accessible by bots, workspaces,
+  and users."
+  [token channel topic]
+  (web/call-and-get-response "channels.setPurpose"
+                             {:token token :channel channel
+                              :topic topic}))
+
+
+(defn unarchive
+  "Unarchives a channel. Callable by workspace and user tokens only."
+  [token channel]
+  (web/call-and-get-response "channels.unarchive"
+                             {:token token :channel channel}))
+

--- a/src/clj_slack_client/chat.clj
+++ b/src/clj_slack_client/chat.clj
@@ -1,0 +1,78 @@
+(ns clj-slack-client.chat
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [update]))
+
+
+(defn delete
+  "Deletes a message. Accessible by bots, workspaces, and users.
+  When used by a bot, may delete only messages posted by that
+  bot user."
+  ([token channel time-stamp]
+   (delete token channel time-stamp false))
+  ([token channel time-stamp as-user]
+   (web/call-and-get-response "chat.delete"
+                              {:token token :channel channel
+                               :ts time-stamp :as_user as-user})))
+
+
+(defn get-permalink
+  "Retrieve a permalink URL for a specific extant message. Easily
+  exchange a message timestamp and a channel ID for a permalink
+  to that message. Accessible by bots and users."
+  [token channel time-stamp]
+  (web/call-and-get-response "chat.getPermalink"
+                             {:token token :channel channel
+                              :message_ts time-stamp}))
+
+
+(defn me-message
+  "Share a me message into a channel. Accessible by bots and users."
+  [token channel text]
+  (web/call-and-get-response "chat.meMessage"
+                             {:token token :channel channel :text text}))
+
+
+(defn post-ephemeral
+  "Sends an ephemeral message to a user in a channel. Accessible
+  by bots, workspaces, and users."
+  ([token channel text user]
+   (post-ephemeral token channel text user {}))
+  ([token channel text user options]
+   (web/call-and-get-response "chat.postEphemeral"
+                              (merge {:token token :channel channel
+                                      :text text :user user}
+                                     options))))
+
+
+(defn post-message
+  "Sends a message to a channel. Accessible by bots, workspaces,
+  and users."
+  ([token channel text]
+   (post-message token channel text {}))
+  ([token channel text options]
+   (web/call-and-get-response "chat.postMessage"
+                              (merge {:token token :channel channel :text text}
+                                     options))))
+
+
+(defn unfurl
+  "Provide custom unfurl behavior for user posted URLs. Accessible
+  by workspaces and users."
+  ([token channel time-stamp unfurls]
+   (unfurl token channel time-stamp unfurls {}))
+  ([token channel time-stamp unfurls options]
+   (web/call-and-get-response "chat.unfurl"
+                              {:token token :channel channel
+                               :ts time-stamp :unfurls unfurls})))
+
+
+(defn update
+  "Updates a message. Accessible by bots, workspaces, and users"
+  ([token channel text time-stamp]
+   (update token channel text time-stamp {}))
+  ([token channel text time-stamp options]
+   (web/call-and-get-response "chat.update"
+                              (merge {:token token :channel channel
+                                      :ts time-stamp :text text}
+                                     options))))
+

--- a/src/clj_slack_client/conversations.clj
+++ b/src/clj_slack_client/conversations.clj
@@ -1,0 +1,141 @@
+(ns clj-slack-client.conversations
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list]))
+
+(def api-module "conversations")
+
+(defn- call
+  ([method-name token]
+   (web/call-and-get-response (str api-module "." method-name) {:token token}))
+  ([method-name token channel]
+   (web/call-and-get-response (str api-module "." method-name)
+                              {:token token :channel channel}))
+  ([method-name token channel options]
+   (web/call-and-get-response (str api-module "." method-name)
+                              (merge {:token token :channel channel}
+                                     options))))
+
+
+(defn archive
+  "Archives a conversation. Callable only by user."
+  [token channel]
+  (call "archive" token channel))
+
+
+(defn close
+  "Closes a direct message. Callable by user and bot tokens."
+  [token channel]
+  (call "close" token channel))
+
+
+(defn create
+  "Initiates a public or private channel-based conversation.
+  Callable only by user token."
+  ([token channel-name]
+   (create token channel-name false))
+  ([token channel-name is-private?]
+   (web/call-and-get-response "create"
+                              {:token token :name channel-name
+                               :is_private is-private?})))
+
+
+(defn history
+  "Fetches a conversation's history of messages and events.
+  Callable by user and bot tokens."
+  ([token channel]
+   (history token channel {}))
+  ([token channel options]
+   (call "history" token channel options)))
+
+
+(defn info
+  "Retrieve information about a conversation. Callable by user
+  and bot tokens."
+  ([token channel]
+   (token channel false))
+  ([token channel include-locale]
+   (call "info" token channel include-locale)))
+
+
+(defn invite
+  "Invites users to a channel. Callable by user only. Users
+  are comma separated."
+  [token channel users]
+  (call "invite" token channel {:users users}))
+
+
+(defn join
+  "Joins an existing conversation. Callably by user only."
+  [token channel]
+  (call "join" token channel))
+
+
+(defn kick
+  "Removes a user from a conversation. Callable by user only."
+  [token channel user]
+  (call "kick" token channel {:user user}))
+
+
+(defn leave
+  "Leaves a conversation. Only callable by user."
+  [token channel]
+  (call "leave" token channel))
+
+
+(defn list
+  "Lists all channels in a Slack team. Accessible by bot and user."
+  ([token]
+   (call "list" token))
+  ([token options]
+   (web/call-and-get-response "conversations.list" {:token token})))
+
+
+(defn members
+  "Retrieve the members of a conversation. Accessible by bots and users."
+  ([token channel]
+   (call "members" token channel))
+  ([token channel options]
+   (call "members" token channel options)))
+
+
+(defn open
+  "Opens or resumes a direct or multi-person message. Callable by bot
+  and user tokens."
+  [token options]
+  (web/call-and-get-response "conversations.open"
+                             (assoc options :token token)))
+
+
+(defn rename
+  "Renames a conversation. Callable only by user."
+  [token channel new-name]
+  (call "rename" token channel {:name new-name}))
+
+
+(defn replies
+  "Retrieve a thread of messages posted to a conversation. Accessible
+  by bot and user tokens."
+  ([token channel time-stamp]
+   (call "replies" token channel {:ts time-stamp}))
+  ([token channel time-stamp options]
+   (call "replies" token channel
+         (assoc options :ts time-stamp))))
+
+
+(defn set-purpose
+  "Sets the purpose for a conversation. Supported by bot and user tokens."
+  [token channel purpose]
+  (call "setPurpose" token channel {:purpose purpose}))
+
+
+(defn set-topic
+  "Sets the topic for a conversation. Supported by bot and user tokens."
+  [token channel topic]
+  (call "setPurpose" token channel {:topic topic}))
+
+
+(defn unarchive
+  "Reverses conversation archival. Supported by users only."
+  [token channel]
+  (call "unarchive" token channel))
+

--- a/src/clj_slack_client/dialog.clj
+++ b/src/clj_slack_client/dialog.clj
@@ -1,0 +1,10 @@
+(ns clj-slack-client.dialog
+  (:require [clj-slack-client.web :as web]))
+
+
+(defn open
+  "Open a dialog with a user. Callable by any token type."
+  [token dialog trigger-id]
+  (web/call-and-get-response "dialog.open"
+                             {:token token :dialog dialog
+                              :trigger_id trigger-id}))

--- a/src/clj_slack_client/dnd.clj
+++ b/src/clj_slack_client/dnd.clj
@@ -21,14 +21,15 @@
               :sec seconds
               :str (str minutes ":" seconds))))
 
-(defn get-user-dnd
-  "Call the Slack dnd.info method for a particular user-id."
+(defn info
+  "Retrieves a user's current Do Not Disturb status. Callable
+  by bot and user tokens."
   [api-token user-id]
   (web/call-and-get-response "dnd.info"
                              {:user user-id :token api-token}))
 
-(defn get-team-dnd
-  "Call the Slack dnd.teamInfo method for the whole team."
+(defn team-info
+  "Retrieves the Do Not Disturb status for users on a team."
   [api-token]
   (web/call-and-get-response "dnd.teamInfo" {:token api-token}))
 

--- a/src/clj_slack_client/emoji.clj
+++ b/src/clj_slack_client/emoji.clj
@@ -1,0 +1,9 @@
+(ns clj-slack-client.emoji
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list]))
+
+
+(defn list
+  "List custom emoji for a team. Callable by all token types."
+  [token]
+  (web/call-and-get-response "emoji.list" {:token token}))

--- a/src/clj_slack_client/files.clj
+++ b/src/clj_slack_client/files.clj
@@ -1,0 +1,59 @@
+(ns clj-slack-client.files
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list]))
+
+(def module-name "files")
+
+(defn- call
+  ([method-name token file]
+   (call method-name token file {}))
+  ([method-name token file options]
+   (web/call-and-get-response (str module-name "." method-name)
+                              (merge {:token token :file file}
+                                     options))))
+
+(defn delete
+  "Deletes a file. Supported by all token types."
+  [token file]
+  (web/call-and-get-response "files.delete"
+                             {:token token :file file}))
+
+
+(defn info
+  "Gets the information about a file. Accessible by all token types."
+  ([token file]
+   (info token file {}))
+  ([token file options]
+   (call "info" token file options)))
+
+
+(defn list
+  "Lists and filters team files. Accessible by workspace and user
+  token types. Returns a list of files within the team. Can be
+  filtered with the options."
+  ([token]
+   (list token {}))
+  ([token options]
+   (web/call-and-get-response "files.list"
+                              (assoc options :token token))))
+
+
+(defn revoke-public-URL
+  "Revokes public/external sharing access for a file. Accessible
+  by workspace and user tokens."
+  [token file]
+  (call "revokePublicURL" token file))
+
+
+(defn shared-public-URL
+  "Enables a file for public/external sharing. Accessible by workspace
+  and user tokens."
+  [token file]
+  (call "sharedPublicURL" token file))
+
+
+(defn upload
+  "Uploads or creates a file. Accessible by all tokens."
+  [token options]
+  (web/call-and-get-response "files.upload"
+                             (assoc options :token token)))

--- a/src/clj_slack_client/files/comments.clj
+++ b/src/clj_slack_client/files/comments.clj
@@ -1,0 +1,27 @@
+(ns clj-slack-client.files.comments
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [comment]))
+
+
+(defn add
+  "Add a comment to an existing file. Callable by bots, workspaces,
+  and user tokens."
+  [token comment file]
+  (web/call-and-get-response "files.comments.add"
+                             {:token token :comment text :file file}))
+
+
+(defn delete
+  "Deletes an existing comment on a file. Callable by all token types."
+  [token file file-comment-id]
+  (web/call-and-get-response "files.comments.delete"
+                             {:token token :file file :id file-comment-id}))
+
+
+(defn edit
+  "Edit an existing file comment. Accessible by all token types."
+  [token comment file file-comment-id]
+  (web/call-and-get-response "files.comments.edit"
+                             {:token token :comment comment
+                              :file file :id file-comment-id}))
+

--- a/src/clj_slack_client/files/comments.clj
+++ b/src/clj_slack_client/files/comments.clj
@@ -8,7 +8,7 @@
   and user tokens."
   [token comment file]
   (web/call-and-get-response "files.comments.add"
-                             {:token token :comment text :file file}))
+                             {:token token :comment comment :file file}))
 
 
 (defn delete

--- a/src/clj_slack_client/groups.clj
+++ b/src/clj_slack_client/groups.clj
@@ -1,0 +1,133 @@
+(ns clj-slack-client.groups
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list]))
+
+(def api-module "groups")
+
+(defn- call
+  ([method-name token]
+   (web/call-and-get-response (str api-module "." method-name) {:token token}))
+  ([method-name token channel]
+   (web/call-and-get-response (str api-module "." method-name)
+                              {:token token :channel channel}))
+  ([method-name token channel options]
+   (web/call-and-get-response (str api-module "." method-name)
+                              (merge {:token token :channel channel}
+                                     options))))
+
+
+(defn archive
+  "Archives a private channel. Callable by workspace and user."
+  [token channel]
+  (call "archive" token channel))
+
+
+(defn create
+  "Creates a private channel. Callable by workspace and user."
+  ([token channel-name]
+   (create token channel-name false))
+  ([token channel-name validate]
+   (web/call-and-get-response "create"
+                              {:token token :name channel-name
+                               :validate validate})))
+
+
+(defn create-child
+  "Clones and archives a private channel. Accessible by user and workspcae
+  tokens."
+  [token channel]
+  (call "createChild" token channel))
+
+
+(defn history
+  "Fetches history of messages and events from a private channel.
+  Callable by bot, user, and workspace tokens."
+  ([token channel]
+   (history token channel {}))
+  ([token channel options]
+   (call "history" token channel options)))
+
+
+(defn info
+  "Gets information about a private channel. Acessible by all token types."
+  ([token channel]
+   (token channel false))
+  ([token channel include-locale]
+   (call "info" token channel include-locale)))
+
+
+(defn invite
+  "Invites a user to a private channel. Accessible by workspace
+  and user tokens."
+  [token channel user]
+  (call "invite" token channel {:user user}))
+
+
+(defn kick
+  "Removes a user from a private channel. Callable by user and
+  workspace tokens." 
+  [token channel user]
+  (call "kick" token channel {:user user}))
+
+
+(defn leave
+  "Leaves a private channel. Only callable by user."
+  [token channel]
+  (call "leave" token channel))
+
+
+(defn list
+  "Lists all private channels that the calling user has access to.
+  Callable by all token types."
+  ([token]
+   (call "list" token))
+  ([token options]
+   (web/call-and-get-response "groups.list" {:token token})))
+
+
+(defn mark
+  "Sets the read cursor in a private channel. Callable by
+  bot and user token types."
+  [token channel time-stamp]
+  (call "mark" token channel {:ts time-stamp}))
+
+
+(defn open
+  "Opens a private channel. Callable by bot and user tokens."
+  [token channel]
+  (call "open" token channel))
+
+
+(defn rename
+  "Renames a private channel. Supported by user and workspace
+  token types."
+  ([token channel new-name]
+   (rename token channel new-name false))
+  ([token channel new-name validate]
+   (call "rename" token channel {:name new-name :validate validate})))
+
+
+(defn replies
+  "Retrieve a thread of messages posted to a private channel.
+  Accessible by user and workspace tokens."
+  [token channel time-stamp]
+  (call "replies" token channel {:ts time-stamp}))
+
+
+(defn set-purpose
+  "Sets the purpose for a private channel. Supported by all token types."
+  [token channel purpose]
+  (call "setPurpose" token channel {:purpose purpose}))
+
+
+(defn set-topic
+  "Sets the topic for a private channel. Supported by all token types."
+  [token channel topic]
+  (call "setPurpose" token channel {:topic topic}))
+
+
+(defn unarchive
+  "Unarchives a private channel. Accessible by workspack and user types."
+  [token channel]
+  (call "unarchive" token channel))
+

--- a/src/clj_slack_client/im.clj
+++ b/src/clj_slack_client/im.clj
@@ -1,0 +1,63 @@
+(ns clj-slack-client.im
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list]))
+
+(def api-module "im")
+
+(defn- call
+  ([method-name token channel]
+   (web/call-and-get-response (str api-module "." method-name)
+                              {:token token :channel channel}))
+  ([method-name token channel options]
+   (web/call-and-get-response (str api-module "." method-name)
+                              (merge {:token token :channel channel}
+                                     options))))
+
+(defn close
+  "Close a direct message channel. Accessible by all token types."
+  [token channel]
+  (call "close" token channel))
+
+
+(defn history
+  "Fetches history of messages and events from direct message channel.
+  Accessible by all token types."
+  ([token channel]
+   (history token channel {}))
+  ([token channel options]
+   (call "history" token channel options)))
+
+
+(defn list
+  "Lists direct message channels for the calling user.
+  Accessible by all tokne types."
+  ([token]
+   (list token {}))
+  ([token options]
+   (web/call-and-get-response "im.list"
+                              (assoc options :token token))))
+
+
+(defn mark
+  "Sets the read cursor in a direct message channel.
+  Accessible by bot and user token types."
+  [token channel time-stamp]
+  (call "mark" token channel {:ts time-stamp}))
+
+
+(defn open
+  "Opens a direct message channel. Supported by bot and user tokens."
+  ([token user]
+   (open token user {}))
+  ([token user options]
+   (web/call-and-get-response "im.open"
+                              (merge {:token token :user user}
+                                     options))))
+
+
+(defn replies
+  "Retrieve a thread of messages posted to a direct message conversation.
+  Accessible by all token types."
+  [token channel time-stamp]
+  (call token channel {:thread_ts time-stamp}))
+

--- a/src/clj_slack_client/migration.clj
+++ b/src/clj_slack_client/migration.clj
@@ -1,0 +1,14 @@
+(ns clj-slack-client.migration
+  (:require [clj-slack-client.web :as web]))
+
+
+(defn exchange
+  "For Enterprise Grid workspaces, map local user IDs to
+  global user IDs. Callable by bot and user tokens. Users
+  are separated by commas."
+  ([token users]
+   (exchange token users false))
+  ([token users to-old]
+    (web/call-and-get-response "migration.exchange"
+                               {:token token :users users
+                                :to_old to-old})))

--- a/src/clj_slack_client/mpim.clj
+++ b/src/clj_slack_client/mpim.clj
@@ -1,0 +1,65 @@
+(ns clj-slack-client.mpim
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list]))
+
+(def api-module "mpim")
+
+(defn- call
+  ([method-name token channel]
+   (web/call-and-get-response (str api-module "." method-name)
+                              {:token token :channel channel}))
+  ([method-name token channel options]
+   (web/call-and-get-response (str api-module "." method-name)
+                              (merge {:token token :channel channel}
+                                     options))))
+
+(defn close
+  "Close a multiparty direct message channel.
+  Accessible by all token types."
+  [token channel]
+  (call "close" token channel))
+
+
+(defn history
+  "Fetches history of messages and events from a 
+  multiparty message channel. Accessible by all token types."
+  ([token channel]
+   (history token channel {}))
+  ([token channel options]
+   (call "history" token channel options)))
+
+
+(defn list
+  "Lists multiparty message channels for the calling user.
+  Accessible by all tokne types."
+  ([token]
+   (list token {}))
+  ([token options]
+   (web/call-and-get-response "im.list"
+                              (assoc options :token token))))
+
+
+(defn mark
+  "Sets the read cursor in a multiparty message channel.
+  Accessible by bot and user token types."
+  [token channel time-stamp]
+  (call "mark" token channel {:ts time-stamp}))
+
+
+(defn open
+  "Opens a multiparty message channel. Supported by bot and user tokens.
+  Users are separated by commas."
+  ([token users]
+   (open token users {}))
+  ([token users options]
+   (web/call-and-get-response "im.open"
+                              (merge {:token token :users users}
+                                     options))))
+
+
+(defn replies
+  "Retrieve a thread of messages posted to a multiparty message conversation.
+  Accessible by all token types."
+  [token channel time-stamp]
+  (call token channel {:thread_ts time-stamp}))
+

--- a/src/clj_slack_client/pins.clj
+++ b/src/clj_slack_client/pins.clj
@@ -1,0 +1,36 @@
+(ns clj-slack-client.pins
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list remove]))
+
+
+(def api-module "pins")
+
+(defn- call
+  ([method-name token channel]
+   (call method-name token channel {}))
+  ([method-name token channel options]
+   (web/call-and-get-response (str api-module "." method-name)
+                              (merge {:token token :channel channel}
+                                     options))))
+
+
+(defn add
+  "Pins an item to a channel. Accessible by all token types.
+  One of file, file comment, or time stamp must also be
+  specified."
+  [token channel options]
+  (call "add" token channel options))
+
+
+(defn list
+  "Lists items pinned to a channel. Accessible by all token types."
+  [token channel]
+  (call "list" token channel))
+
+
+(defn remove
+  "Un-pins an item from a channel. Accessible by all token types.
+  One of file, file comment, or time-stamp must be specified in
+  the options."
+  [token channel options]
+  (call "remove" token channel options))

--- a/src/clj_slack_client/reactions.clj
+++ b/src/clj_slack_client/reactions.clj
@@ -10,7 +10,7 @@
   "Call the slack api"
   [method-name token options]
   (web/call-and-get-response method-name
-                             (assoc aptions :token token)))
+                             (assoc options :token token)))
 
 
 (defn add

--- a/src/clj_slack_client/reactions.clj
+++ b/src/clj_slack_client/reactions.clj
@@ -1,0 +1,44 @@
+(ns clj-slack-client.reactions
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [get list remove]))
+
+; all methods are available by all tokens: bots, workspaces,
+; and user. Each method has a large number of options, which
+; are all available at api.slack.com/methods/reactions.<method-name>
+
+(defn- call
+  "Call the slack api"
+  [method-name token options]
+  (web/call-and-get-response method-name
+                             (assoc aptions :token token)))
+
+
+(defn add
+  "Adds a reaction to an item. You can associate a reaction
+  name with one of a file, file comment, or the combination
+  of channel and timestamp."
+  [token reaction-name options]
+  (call "reactions.add" (assoc options :name reaction-name)))
+
+
+(defn get
+  "Gets the reaction for an item. Returns a list of all
+  reactions for a single item, which can be a file, file
+  comment, channel message, group message, or DM."
+  [token options]
+  (call "reactions.get" token options))
+
+
+(defn list
+  "Lists the reactions made by a user. Returns the list
+  of all items reacted to by a user"
+  [token options]
+  (call "reactions.list" token options))
+
+
+(defn remove
+  "Removes a reaction from an item. One of file, file comment,
+  or the combination of channel and timestamp must be specified."
+  [token options]
+  (call "reactions.remove" token options))
+

--- a/src/clj_slack_client/reminders.clj
+++ b/src/clj_slack_client/reminders.clj
@@ -1,0 +1,43 @@
+(ns clj-slack-client.reminders
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list]))
+
+; these methods only accessible by user tokens. Bots and
+; workspaces are not allowed
+
+(defn add
+  "Creates a reminder."
+  ([options]
+   (web/call-and-get-response "reminders.add" options))
+  ([token text time]
+   (add {:token token :text text :time time}))
+  ([token text time user]
+   (add {:token token :text text :time time :user user})))
+
+
+(defn complete
+  "Marks a reminder as complete."
+  [token reminder-id]
+  (web/call-and-get-response "reminders.complete"
+                             {:token token :reminder reminder-id}))
+
+
+(defn delete
+  "Deletes a reminder."
+  [token reminder-id]
+  (web/call-and-get-response "reminders.delete"
+                             {:token token :reminder reminder-id}))
+
+
+(defn info
+  "Gets information about a reminder"
+  [token reminder-id]
+  (web/call-and-get-response "reminders.info"
+                             {:token token :reminder reminder-id}))
+
+
+(defn list
+  "Lists all reminders created by or for a given user."
+  [token]
+  (web/call-and-get-response "reminders.list" {:token token}))
+

--- a/src/clj_slack_client/search.clj
+++ b/src/clj_slack_client/search.clj
@@ -1,0 +1,35 @@
+(ns clj-slack-client.search
+  (:require [clj-slack-client.web :as web]))
+
+; N.B.: all of these are not bot accessible. Each have extensive
+; options available at api.slack.com/methods/search.<method-name>
+
+(defn all
+  "Searches for messages and files matching a query."
+  ([token query]
+   (web/call-and-get-response "search.all"
+                              {:token token :query query}))
+  ([token query options]
+   (web/call-and-get-response "search.all"
+                              (merge {:token token :query query} options))))
+
+
+(defn files
+  "Searches for files matching a query."
+  ([token query]
+   (web/call-and-get-response "search.files"
+                              {:token token :query query}))
+  ([token query options]
+   (web/call-and-get-response "search.files"
+                              (merge {:token token :query query} options))))
+
+
+(defn messages
+  "Searches for messages matching a query."
+  ([token query]
+   (web/call-and-get-response "search.messages"
+                              {:token token :query query}))
+  ([token query options]
+   (web/call-and-get-response "search.messages"
+                              (merge {:token token :query query} options))))
+

--- a/src/clj_slack_client/stars.clj
+++ b/src/clj_slack_client/stars.clj
@@ -7,7 +7,7 @@
   "Call the slack api"
   [method-name token options]
   (web/call-and-get-response method-name
-                             (assoc aptions :token token)))
+                             (assoc options :token token)))
 
 ; all of these methods are accessible by bots, workspaces, and users.
 ; each have extensive options available at

--- a/src/clj_slack_client/stars.clj
+++ b/src/clj_slack_client/stars.clj
@@ -1,0 +1,39 @@
+(ns clj-slack-client.stars
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list remove]))
+
+
+(defn- call
+  "Call the slack api"
+  [method-name token options]
+  (web/call-and-get-response method-name
+                             (assoc aptions :token token)))
+
+; all of these methods are accessible by bots, workspaces, and users.
+; each have extensive options available at
+; api.slack.com/methods/stars.<method-name>
+
+(defn add
+  "Adds a star to an item. One of file, file comment, channel,
+  or the combination of channel and timestamp. Accessible by
+  bots, workspaces, and users"
+  [token options]
+  (call "stars.add" token options))
+
+
+(defn list
+  "List the stars for a user. Not accessible by bots. Takes
+  optional options of count, the number of items per page
+  to return, and page, the page number of results to return"
+  ([token]
+   (list token {}))
+  ([token options]
+   (call "stars.list" token options)))
+
+
+(defn remove
+  "Removes a star to an item. One of file, file comment, channel,
+  or the combination of channel and timestamp. Accessible by
+  bots, workspaces, and users"
+  [token options]
+  (call "stars.add" token options))

--- a/src/clj_slack_client/team.clj
+++ b/src/clj_slack_client/team.clj
@@ -1,0 +1,38 @@
+(ns clj-slack-client.team
+  (:require [clj-slack-client.web :as web]))
+
+
+(defn access-logs
+  "Gets the access logs for the current team. Only accessible by user."
+  ([token]
+   (access-logs {}))
+  ([token options]
+   (web/call-and-get-response "team.accessLogs"
+                              (assoc options :token token))))
+
+
+(defn billable-info
+  "Gets the billable users information for the current team.
+  Only accessible by user."
+  ([token]
+   (web/call-and-get-response "team.billableInfo" {:token token}))
+  ([token user]
+   (web/call-and-get-response "team.billableInfo"
+                              {:token token :user user})))
+
+
+(defn info
+  "Gets information about the current team. Accessible by all token types."
+  [token]
+  (web/call-and-get-response "team.info" {:token token}))
+
+
+(defn integration-logs
+  "Gets the integration logs for the current team. Accessible by workspace
+  and user token types."
+  ([token]
+   (integration-logs {}))
+  ([token options]
+   (web/call-and-get-response "team.integrationLogs"
+                              (assoc options :token token))))
+

--- a/src/clj_slack_client/usergroups.clj
+++ b/src/clj_slack_client/usergroups.clj
@@ -1,0 +1,56 @@
+(ns clj-slack-client.usergroups
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list update]))
+
+
+(defn create
+  "Create a user group. Accessible to workspace and user tokens."
+  ([token new-name]
+   (create token new-name {}))
+  ([token new-name options]
+   (web/call-and-get-response "usergroups.create"
+                              (merge {:token token :name new-name}
+                                     options))))
+
+
+(defn disable
+  "Disable an existing user group. Accessible by workspace and user
+  token types."
+  ([token usergroup]
+   (disable token usergroup false))
+  ([token usergroup include-count]
+   (web/call-and-get-response "usergroups.disable"
+                              {:token token :usergroup usergroup
+                               :include_count include-count})))
+
+
+(defn enable
+  "Enable a user group. Accessible by workspace and user token types."
+  ([token usergroup]
+   (disable token usergroup false))
+  ([token usergroup include-count]
+   (web/call-and-get-response "usergroups.enable"
+                              {:token token :usergroup usergroup
+                               :include_count include-count})))
+
+
+(defn list
+  "List all user groups for a team. Accessible by workspace
+  and user token types."
+  ([token]
+   (list token {}))
+  ([token options]
+   (web/call-and-get-response "usergroups.list"
+                              (assoc options :token token))))
+
+
+(defn update
+  "Update an existing user group. Accessible by workspace and user
+  token types."
+  ([token usergroup]
+   (create token usergroup {}))
+  ([token usergroup options]
+   (web/call-and-get-response "usergroups.update"
+                              (merge {:token token :usergroup usergroup}
+                                     options))))
+

--- a/src/clj_slack_client/usergroups/users.clj
+++ b/src/clj_slack_client/usergroups/users.clj
@@ -1,0 +1,26 @@
+(ns clj-slack-client.usergroups.users
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [list update]))
+
+
+(defn list
+  "List all users in a user group. Accessible by workspace and user
+  token types."
+  ([token usergroup]
+   (list token usergroup false))
+  ([token usergroup include-disabled]
+   (web/call-and-get-response "usergroups.users.list"
+                              {:token token :usergroup usergroup
+                               :include_disabled include-disabled})))
+
+
+(defn update
+  "Update the list of users for a User Group. Accessible by user
+  and workspace token types. Users are comma separated."
+  ([token usergroup users]
+   (update token usergroup users true))
+  ([token usergroup users include-count]
+   (web/call-and-get-response "usergroups.users.update"
+                              {:token token :usergroup usergroup
+                               :users users :include_count include-count})))
+

--- a/src/clj_slack_client/users.clj
+++ b/src/clj_slack_client/users.clj
@@ -1,0 +1,73 @@
+(ns clj-slack-client.users
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [identity list]))
+
+
+(defn delete-photo
+  "Delete the user profile photo. Only accessible by user token."
+  [token]
+  (web/call-and-get-response "users.deletePhoto" {:token token}))
+
+
+(defn get-presence
+  "Gets user presence information. Callable by bot and user token types."
+  [token user-id]
+  (web/call-and-get-response "users.getPresence" {:token token :user user-id}))
+
+
+(defn identity
+  "Get's a user's identity. Accessible by workspace and user tokens."
+  [token]
+  (web/call-and-get-response "users.identity" {:token token}))
+
+
+(defn info
+  "Gets information about a user. Accessible by all token types."
+  ([token user]
+   (info token user false))
+  ([token user include-local]
+   (web/call-and-get-response "users.info"
+                              {:token token :user user
+                               :include_local include-local})))
+
+
+(defn list
+  "Lists all users in a Slack team. Accessible by all token types."
+  ([token]
+   (list token {}))
+  ([token options]
+   (web/call-and-get-response "users.list"
+                              (assoc options :token token))))
+
+
+(defn lookup-by-email
+  "Find a user with an email address. Accessibl by all token types."
+  [token email]
+  (web/call-and-get-response "users.lookupByEmail"
+                             {:token token :email email}))
+
+
+(defn set-active
+  "Marks a user as active. Accessible by user and bot tokens."
+  [token]
+  (web/call-and-get-response "users.setActive" {:token token}))
+
+
+(defn set-photo
+  "Set the user profile photo. Accessible by user token. The
+  image is in multipart/form-data form."
+  ([token image]
+   (set-photo token image {}))
+  ([token image options]
+   (web/call-and-get-response "users.setPhoto"
+                              (merge {:token token :image image}
+                                     options))))
+
+
+(defn set-presence
+  "Manually set user presence. Accessible by bot or user forms.
+  Presence can either be away or auto."
+  [token presence]
+  (web/call-and-get-response "users.setPresence"
+                             {:token token :presence presence}))
+

--- a/src/clj_slack_client/users/profile.clj
+++ b/src/clj_slack_client/users/profile.clj
@@ -1,0 +1,23 @@
+(ns clj-slack-client.users.profile
+  (:require [clj-slack-client.web :as web])
+  (:refer-clojure :exclude [get set]))
+
+
+(defn get
+  "Retrieves a user's profile information. Supported by workspace and
+  user token types."
+  ([token]
+   (get token {}))
+  ([token options]
+   (web/call-and-get-response "users.profile.get"
+                              (assoc options :token token))))
+
+
+(defn set
+  "Set the profile information for a user. Supported by user token types."
+  ([token]
+   (set token {}))
+  ([token options]
+   (web/call-and-get-response "users.profile.set"
+                              (assoc options :token token))))
+


### PR DESCRIPTION
Each method in the API has a corresponding function with the style changed from periods and camelCase to slashes and hyphens. For example, `dnd.setSnooze` would be under `clj-slack-client.dnd/set-snooze`. When `require`-ed as usual, it would be `dnd/set-snooze`. Every function follows a basic layout, making it easy to pick up how to use the library. Each module of the API is separate and has basic functionality, but is easily extendable by PR if any developers find creative needs for functions.